### PR TITLE
Support Rust beta and Windows MSYS compiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,8 @@ license = "MIT/Apache-2.0"
 
 build = "build.rs"
 
+[dependencies]
+libc = "*"
+
 [build-dependencies.pkg-config]
 git = "https://github.com/alexcrichton/pkg-config-rs"

--- a/examples/factorial.rs
+++ b/examples/factorial.rs
@@ -1,12 +1,10 @@
-#![feature(core)]
-
 #[macro_use]
 extern crate qmlrs;
 
 struct Factorial;
 impl Factorial {
     fn calculate(&self, x: i64) -> i64 {
-        std::iter::range_inclusive(1, x).fold(1, |t,c| t * c)
+        (1..x+1).fold(1, |t,c| t * c)
     }
 }
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -9,7 +9,7 @@ pub enum QVariant {}
 pub enum QVariantList {}
 
 #[repr(C)]
-#[derive(Eq, PartialEq, Debug, Copy)]
+#[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum QrsVariantType {
     Invalid = 0,
     Int64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(unboxed_closures, unsafe_destructor, libc, convert)]
-
 extern crate libc;
 
 use libc::{c_char, c_int, c_uint, c_void};
@@ -108,9 +106,14 @@ impl Engine {
     }
 
     pub fn load_local_file<P: AsRef<Path>>(&mut self, name: P) {
-        let path = std::env::current_dir().unwrap().join(name);
-
-        self.load_url(&format!("file://{}", path.display()));
+        let path_raw = std::env::current_dir().unwrap().join(name);
+        let path
+            = if cfg!(windows) {
+                format!("/{}",path_raw.display())
+            } else {
+                format!("{}",path_raw.display())
+            } ;
+        self.load_url(&path);
     }
 
     pub fn exec(self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,9 +109,9 @@ impl Engine {
         let path_raw = std::env::current_dir().unwrap().join(name);
         let path
             = if cfg!(windows) {
-                format!("/{}",path_raw.display())
+                format!("file:///{}",path_raw.display())
             } else {
-                format!("{}",path_raw.display())
+                format!("file://{}",path_raw.display())
             } ;
         self.load_url(&path);
     }


### PR DESCRIPTION
* Main changes:
 * Support Rust beta instead of just nightly build.  Avoid unstable features (e.g., use libc from crates.io)
 * Slight tweaks to handle Windows/MSYS
 