### PR TITLE
Allow loading QML from string (issue #1)

### DIFF
--- a/examples/factorial.rs
+++ b/examples/factorial.rs
@@ -1,6 +1,9 @@
 #[macro_use]
 extern crate qmlrs;
 
+use std::fs::File;
+use std::io::prelude::*;
+
 struct Factorial;
 impl Factorial {
     fn calculate(&self, x: i64) -> i64 {
@@ -20,4 +23,15 @@ fn main() {
     engine.load_local_file("examples/factorial_ui.qml");
 
     engine.exec();
+
+    // test with string:
+    let mut engine2 = qmlrs::Engine::new();
+    engine2.set_property("factorial", Factorial);
+    let mut qml_file = File::open("examples/factorial_ui.qml").unwrap();
+    let mut qml_string = String::new();
+    qml_file.read_to_string(&mut qml_string).unwrap();
+    qml_string = qml_string.replace("Factorial", "Factorial (from string)");
+    engine2.load_data(&qml_string);
+
+    engine2.exec();
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -23,6 +23,7 @@ extern "C" {
     pub fn qmlrs_create_engine_headless() -> *mut QrsEngine;
     pub fn qmlrs_destroy_engine(engine: *mut QrsEngine);
     pub fn qmlrs_engine_load_url(engine: *mut QrsEngine, path: *const c_char, len: c_uint);
+    pub fn qmlrs_engine_load_from_data(engine: *mut QrsEngine, data: *const c_char, len: c_uint);
     pub fn qmlrs_engine_invoke(engine: *mut QrsEngine, method: *const c_char, result: *mut QVariant,
                                args: *const QVariantList);
     pub fn qmlrs_engine_set_property(engine: *mut QrsEngine, name: *const c_char, len: c_uint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,15 @@ impl Engine {
         }
     }
 
+    pub fn load_data(&mut self, data: &str) {
+        unsafe {
+            ffi::qmlrs_engine_load_from_data(self.i.p, data.as_ptr() as *const c_char,
+                                             data.len() as c_uint);
+        }
+    }
+
+
+
     pub fn load_local_file<P: AsRef<Path>>(&mut self, name: P) {
         let path_raw = std::env::current_dir().unwrap().join(name);
         let path


### PR DESCRIPTION
added function `load_data` to `Engine`
added example (did not use  include_str!(), but create a string from the example QML file)