### PR TITLE
packed attribute was removed, fix compilation on rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub struct Engine {
     i: Arc<EngineInternal>,
 }
 
-#[packed]
+#[repr(packed)]
 struct PropHdr<T: Object> {
     qobj: *mut QObject,
     obj: T


### PR DESCRIPTION
See: https://github.com/rust-lang/rust/pull/25541 or "For consistency, specifying a packed
layout is now also down with #[repr(packed)]" here: https://github.com/rust-lang/rust/commit/6e8ff999589a7b4c7f62f7128f3e028a7b3ea64f
changing from #[packed] to #[repr(packed)] should fix the compilation issues with rust nightly (see #16 #15, and #19)