### PR TITLE
The order of values in QrsVariantType was different in ffi.rs and in …

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -12,8 +12,8 @@ pub enum QVariantList {}
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum QrsVariantType {
     Invalid = 0,
-    Bool,
     Int64,
+    Bool,
     String
 }
 


### PR DESCRIPTION
…libqmlrswrapper.cpp, causing the Factorial example to fail