### PR TITLE
Cache meta objects

### DIFF
--- a/examples/factorial.rs
+++ b/examples/factorial.rs
@@ -11,7 +11,7 @@ impl Factorial {
     }
 }
 
-Q_OBJECT! { Factorial:
+Q_OBJECT! { Factorial [ FACTORIAL_METAOBJ ] :
     slot fn calculate(i64);
 //    signal fn test();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod macros;
 mod variant;
 
 pub trait Object {
-    fn qt_metaobject(&self) -> MetaObject;
+    fn qt_metaobject(&self) -> &'static MetaObject;
     fn qt_metacall(&mut self, slot: i32, args: *const *const OpaqueQVariant);
 }
 
@@ -151,8 +151,6 @@ impl Engine {
         }
     }
 }
-
-/* MetaObjects currently leak. Once a cache system is implemented, this should be fine. */
 
 #[allow(missing_copy_implementations)]
 pub struct MetaObject {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! Q_OBJECT(
     (
-        $t:ty :
+        $t:ty [ $c:ident ] :
             $(
                 slot fn $name:ident ( $($at:ty),* );
             )*
@@ -32,25 +32,34 @@ macro_rules! Q_OBJECT(
                 }
             )+
         }
+
 */
+        static mut $c: Option<qmlrs::MetaObject> = None;
+
         impl qmlrs::Object for $t {
             #[allow(unused_mut, unused_variables)]
-            fn qt_metaobject(&self) -> qmlrs::MetaObject {
-                let x = qmlrs::MetaObject::new();
-/*
-                $(
-                    let x = x.signal(stringify!($sname), 0);
-                )+
-*/
-                $(
-                    let mut argc = 0;
-                    $(
-                        let _: $at;
-                        argc += 1;
-                    )*
-                    let x = x.slot(stringify!($name), argc);
-                )+
-                x
+            fn qt_metaobject(&self) -> &'static qmlrs::MetaObject {
+                unsafe {
+                    if $c.is_none() {
+                        let x = qmlrs::MetaObject::new();
+        /*
+                        $(
+                            let x = x.signal(stringify!($sname), 0);
+                        )+
+        */
+                        $(
+                            let mut argc = 0;
+                            $(
+                                let _: $at;
+                                argc += 1;
+                            )*
+                            let x = x.slot(stringify!($name), argc);
+                        )+
+
+                        $c = Some(x)
+                    }
+                    return $c.as_ref().unwrap();
+                }
             }
 
             #[allow(unused_assignments, unused_mut, unused_variables)]


### PR DESCRIPTION
Uses a type-wide ``static mut`` to cache the QrsDynamicMetaObject. The downside of this solution is that it is unsafe and requires another argument for the Q_OBJECT macro (at least until concat_idents! is stable).