### PR TITLE
Fix multiple slot arguments issue

### DIFF
--- a/examples/multiply.rs
+++ b/examples/multiply.rs
@@ -1,0 +1,23 @@
+#[macro_use]
+extern crate qmlrs;
+
+
+struct Multiply;
+impl Multiply {
+    fn calculate(&self, x: i64, y: i64) -> i64 {
+        x * y
+    }
+}
+
+Q_OBJECT! { Multiply:
+    slot fn calculate(i64, i64);
+}
+
+fn main() {
+    let mut engine = qmlrs::Engine::new();
+
+    engine.set_property("multiply", Multiply);
+    engine.load_local_file("examples/multiply_ui.qml");
+
+    engine.exec();
+}

--- a/examples/multiply_ui.qml
+++ b/examples/multiply_ui.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.0
+
+ApplicationWindow {
+    visible: true
+    title: "Multiply"
+
+    property int margin: 11
+    width: mainLayout.implicitWidth + 2 * margin
+    height: mainLayout.implicitHeight + 2 * margin
+    minimumWidth: mainLayout.Layout.minimumWidth + 2 * margin
+    minimumHeight: mainLayout.Layout.minimumHeight + 2 * margin
+
+    ColumnLayout {
+        id: mainLayout
+        anchors.fill: parent
+        anchors.margins: margin
+
+        RowLayout {
+            TextField {
+                id: number1Field
+                Layout.fillWidth: true
+
+                placeholderText: "Enter number"
+                focus: true
+
+                onAccepted: doCalculate()
+            }
+
+            Label {
+                text: "*"
+            }
+
+            TextField {
+                id: number2Field
+                Layout.fillWidth: true
+                placeholderText: "Enter number"
+
+                onAccepted: doCalculate()
+            }
+
+            Button {
+                text: "Calculate"
+
+                onClicked: doCalculate()
+            }
+        }
+
+        TextArea {
+            id: resultArea
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+
+    function doCalculate() {
+        var num1 = parseInt(number1Field.text);
+        var num2 = parseInt(number2Field.text);
+        resultArea.text = multiply.calculate(num1, num2);
+    }
+
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -78,7 +78,7 @@ macro_rules! Q_OBJECT(
                                         }
                                     }
                                 }
-                            )*
+                            ),*
                         );
                         ret.to_qvariant(unsafe { *args.offset(0) as *mut qmlrs::OpaqueQVariant });
                         return


### PR DESCRIPTION
Fixes #24 and adds a multiply example to test multiple argument slots. Couldn't find a way to write a test, as this probably would need some signalling from rust to qml.