### PR TITLE
added ext/libqmlrswrapper/build to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+ext/libqmlrswrapper/build


### PR DESCRIPTION
so that the C++ binary files can't get into the repository.