### PR TITLE
Make build.rs play nice with OSX + homebrew.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ extern crate pkg_config;
 
 use std::process::Command;
 use std::fs;
+use std::path::Path;
 use std::env;
 use std::path::PathBuf;
 
@@ -12,6 +13,34 @@ fn main() {
     let _ = fs::create_dir_all(&build);
 
     let mut myargs = vec![".."] ;
+
+    /*
+     * Prameters for supporting QT on OS X installed via homebres
+     *
+     * Because QT5 conflicts with QT4 the homebrew package manager won't link
+     * the QT5 package into the default search paths for libraries, to deal
+     * with this we need to give pkg-config and cmake a nudge in the right
+     * direction.
+     */
+    if cfg!(target_os = "macos") {
+        // Point at homebrew's QT5 install location, this will likely fail if
+        // another package manager was used.
+        let qt5_lib_path = Path::new("/usr/local/opt/qt5/lib");
+
+        if Path::exists(qt5_lib_path) {
+            // First nudge cmake in the direction of the .cmake files added by
+            // homebrew. This clobbers the existing value if present, it's
+            // unlikely to be present though.
+            env::set_var("CMAKE_PREFIX_PATH", qt5_lib_path.join("cmake"));
+
+            // Nudge pkg-config in the direction of the brewed QT to ensure the
+            // correct compiler flags get found for the project.
+            env::set_var("PKG_CONFIG_PATH", qt5_lib_path.join("pkgconfig"));
+        } else {
+            panic!("The QT5 was not found at the expected location ({}) please install it via homebrew.", qt5_lib_path.display());
+        }
+    }
+
     let is_msys = env::var("MSYSTEM").is_ok() ;
     if cfg!(windows) && is_msys {
         myargs.push("-GMSYS Makefiles") ;


### PR DESCRIPTION
Since QT5 and QT4 supply many of the same libs and QT4 is much more
widely used (according to the Formula's keg_only declaration) homebrew
doesn't link QT5 by default. To work around this we need to nudge
pkg-config and cmake in the right direction for them to find QT5.

Fixes #25