### PR TITLE
Support ChartView

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -89,5 +89,5 @@ fn main() {
     println!("cargo:rustc-link-lib=static=qmlrswrapper");
     println!("cargo:rustc-link-lib=dylib=stdc++");
     println!("cargo:rustc-link-search=native={}",build.display());
-    pkg_config::find_library("Qt5Core Qt5Gui Qt5Qml Qt5Quick Qt5Widgets Qt5Charts").unwrap();
+    pkg_config::find_library("Qt5Core Qt5Gui Qt5Qml Qt5Quick Qt5Widgets").unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -89,5 +89,5 @@ fn main() {
     println!("cargo:rustc-link-lib=static=qmlrswrapper");
     println!("cargo:rustc-link-lib=dylib=stdc++");
     println!("cargo:rustc-link-search=native={}",build.display());
-    pkg_config::find_library("Qt5Core Qt5Gui Qt5Qml Qt5Quick").unwrap();
+    pkg_config::find_library("Qt5Core Qt5Gui Qt5Qml Qt5Quick Qt5Widgets Qt5Charts").unwrap();
 }

--- a/ext/libqmlrswrapper/CMakeLists.txt
+++ b/ext/libqmlrswrapper/CMakeLists.txt
@@ -18,10 +18,11 @@ endif()
 
 find_package(Qt5Core)
 find_package(Qt5Quick)
+find_package(Qt5Widgets)
 
 set(qmlrswrapper_SRCS libqmlrswrapper.cpp qrsdynamicobject.cpp qrsdynamicobject_capi.cpp)
 
 add_library(qmlrswrapper STATIC ${qmlrswrapper_SRCS})
-target_link_libraries(qmlrswrapper Qt5::Core Qt5::Quick)
+target_link_libraries(qmlrswrapper Qt5::Core Qt5::Quick Qt5::Widgets)
 
 install(TARGETS qmlrswrapper ARCHIVE DESTINATION lib)

--- a/ext/libqmlrswrapper/libqmlrswrapper.cpp
+++ b/ext/libqmlrswrapper/libqmlrswrapper.cpp
@@ -4,6 +4,7 @@
 
 #include <QtQuick>
 #include <QDebug>
+#include <QApplication>
 
 #define rust_fun extern "C"
 
@@ -24,7 +25,7 @@ rust_fun QrsApplicationEngine *qmlrs_create_engine_headless() {
 }
 
 rust_fun QrsApplicationEngine *qmlrs_create_engine() {
-    if (!QGuiApplication::instance()) {
+    if (!QApplication::instance()) {
         char *arg = (char *)malloc(13);
         strcpy(arg, "qmlrswrapper");
         char **argp = (char **)malloc(sizeof(char *));
@@ -33,7 +34,7 @@ rust_fun QrsApplicationEngine *qmlrs_create_engine() {
         int *argc = (int *)malloc(sizeof(int));
         *argc = 1;
 
-        new QGuiApplication(*argc, argp);
+        new QApplication(*argc, argp);
     }
 
     return new QrsApplicationEngine();
@@ -92,7 +93,7 @@ rust_fun QVariant *qmlrs_varlist_get(const QVariantList *list, unsigned int i) {
 }
 
 rust_fun void qmlrs_app_exec() {
-    QGuiApplication::exec();
+    QApplication::exec();
 }
 
 rust_fun void qmlrs_variant_set_int64(QVariant *v, int64_t x) {


### PR DESCRIPTION
Without this a qml file using a [ChartView](http://doc.qt.io/qt-5/qml-qtcharts-chartview.html) will crash at runtime. According to https://stackoverflow.com/questions/51532648/qml-crash-in-qt-5-9-help-to-read-stack-trace this is expected and an application using ChartView needs to use `QApplication` instead of `QGuiApplication`. This also matches the [Qt Charts documentation](http://doc.qt.io/qt-5/qtcharts-index.html):
> Note: Projects created with Qt Creator's Qt Quick Application wizard are based on the Qt Quick 2 template that uses QGuiApplication by default. All such QGuiApplication instances in the project must be replaced with QApplication as the module depends on Qt's Graphics View Framework for rendering.